### PR TITLE
change refer hello function from . to ::

### DIFF
--- a/src/rust/r5/setup.md
+++ b/src/rust/r5/setup.md
@@ -159,7 +159,7 @@ mod utils;          // 👈 include utils file.
 use utils::say;     // 👈 and use.
 
 fn main() {
-  say.hello();      // 👈 then call hello function.
+  say::hello();      // 👈 then call hello function.
 }
 ```
 


### PR DESCRIPTION
P'Katopz krab. I tried following the example and got an error like this.

say.hello();      // 👈 then call hello function.
  |   ^^^- help: use the path separator to refer to an item: `::`

I tried to change say.hello  -> say::hello it work!!
I'm not sure what I did wrong or not.